### PR TITLE
Add extra options, fix issues

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
 
   <div id="narration">
     <div id="contents">
-      <div id="space-at-the-top" class="space-at-the-top"></div>
+      <div id="space-at-the-top"></div>
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
     </div>
   </div>
 
+  <div class="loader">Loading...</div>
   <div id="map"></div>
 
   <script type="text/javascript">

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -15,4 +15,9 @@ var constants = {
 	_zoomControls: 'Zoom Controls',
   _narrativeWidth: 'Narrative Width',
   _imgContainerHeight: 'Image Container Height',
+  _pixelsAfterFinalChapter: 'Pixels After Final Chapter',
+  _narrativeBackground: 'Narrative Background Color',
+  _narrativeText: 'Narrative Text Color',
+  _narrativeActive: 'Active Chapter Background Color',
+  _narrativeLink: 'Narrative Link Color',
 };

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -13,4 +13,6 @@ var constants = {
 	// Map Settings
 	_tileProvider: 'Basemap Tiles',
 	_zoomControls: 'Zoom Controls',
+  _narrativeWidth: 'Narrative Width',
+  _imgContainerHeight: 'Image Container Height',
 };

--- a/scripts/storymap.js
+++ b/scripts/storymap.js
@@ -177,6 +177,10 @@ $(window).on('load', function() {
       bounds.push(markers[i].getLatLng());
     }
     map.fitBounds(bounds);
+
+    $('#map, #narration, #title').css('visibility', 'visible');
+    $('div.loader').css('visibility', 'hidden');
+
     $('div#contents').animate({scrollTop: '1px'});
   }
 

--- a/scripts/storymap.js
+++ b/scripts/storymap.js
@@ -117,11 +117,6 @@ $(window).on('load', function() {
 
       markers.push(marker);
 
-      var chapter = $('<p></p>', {
-        text: c['Chapter'],
-        class: 'chapter-header'
-      });
-
       var image = $('<img>', {
         src: c['Image Link'],
       });
@@ -133,11 +128,6 @@ $(window).on('load', function() {
         class: 'source'
       });
 
-      var description = $('<p></p>', {
-        text: c['Description'],
-        class: 'description'
-      });
-
       var container = $('<div></div>', {
         id: 'container' + i,
         class: 'image-container'
@@ -145,10 +135,14 @@ $(window).on('load', function() {
 
       var imgHolder = $('<div></div', {
         class: 'img-holder'
-      });
+      }).append(image);
 
-      imgHolder.append(image);
-      container.append(chapter).append(imgHolder).append(source).append(description);
+      container
+        .append('<p class="chapter-header">' + c['Chapter'] + '</p>')
+        .append(imgHolder)
+        .append(source)
+        .append('<p class="description">' + c['Description'] + '</p>');
+
       $('#contents').append(container);
     }
 

--- a/scripts/storymap.js
+++ b/scripts/storymap.js
@@ -79,7 +79,16 @@ $(window).on('load', function() {
     var options = mapData.sheets(constants.optionsSheetName).elements;
     createDocumentSettings(options);
 
-    var imageContainerMargin = 70;
+    /* Change narrative width */
+    narrativeWidth = parseInt(getSetting('_narrativeWidth'));
+    if (narrativeWidth > 0 && narrativeWidth < 100) {
+      var mapWidth = 100 - narrativeWidth;
+
+      $('#narration, #title').css('width', narrativeWidth + 'vw');
+      $('#map').css('width', mapWidth + 'vw');
+    }
+
+    var chapterContainerMargin = 70;
 
     document.title = getSetting('_mapTitle');
     $('#title').append('<h3>' + getSetting('_mapTitle') + '</h3>');
@@ -130,16 +139,16 @@ $(window).on('load', function() {
 
       var container = $('<div></div>', {
         id: 'container' + i,
-        class: 'image-container'
+        class: 'chapter-container'
       });
 
-      var imgHolder = $('<div></div', {
-        class: 'img-holder'
+      var imgContainer = $('<div></div', {
+        class: 'img-container'
       }).append(image);
 
       container
         .append('<p class="chapter-header">' + c['Chapter'] + '</p>')
-        .append(imgHolder)
+        .append(imgContainer)
         .append(source)
         .append('<p class="description">' + c['Description'] + '</p>');
 
@@ -148,17 +157,26 @@ $(window).on('load', function() {
 
     changeAttribution();
 
+    /* Change image container heights */
+    imgContainerHeight = parseInt(getSetting('_imgContainerHeight'));
+    if (imgContainerHeight > 0) {
+      $('.img-container').css({
+        'height': imgContainerHeight + 'px',
+        'max-height': imgContainerHeight + 'px',
+      });
+    }
+
     // Calculate heights
     pixelsAbove[0] = -100;
     for (i = 1; i < chapters.length; i++) {
-      pixelsAbove[i] = pixelsAbove[i-1] + $('div#container' + (i-1)).height() + imageContainerMargin;
+      pixelsAbove[i] = pixelsAbove[i-1] + $('div#container' + (i-1)).height() + chapterContainerMargin;
     }
     pixelsAbove.push(Number.MAX_VALUE);
 
     $('div#contents').scroll(function() {
       for (i = 0; i < pixelsAbove.length - 1; i++) {
-        if ($(this).scrollTop() >= pixelsAbove[i] && $(this).scrollTop() < (pixelsAbove[i+1] - 2 * imageContainerMargin)) {
-          $('.image-container').removeClass("inFocus").addClass("outFocus");
+        if ($(this).scrollTop() >= pixelsAbove[i] && $(this).scrollTop() < (pixelsAbove[i+1] - 2 * chapterContainerMargin)) {
+          $('.chapter-container').removeClass("inFocus").addClass("outFocus");
           $('div#container' + i).addClass("inFocus").removeClass("outFocus");
           map.flyTo([chapters[i]['Longitude'], chapters[i]['Latitude']], chapters[i]['Zoom']);
         }

--- a/scripts/storymap.js
+++ b/scripts/storymap.js
@@ -176,15 +176,46 @@ $(window).on('load', function() {
     $('div#contents').scroll(function() {
       for (i = 0; i < pixelsAbove.length - 1; i++) {
         if ($(this).scrollTop() >= pixelsAbove[i] && $(this).scrollTop() < (pixelsAbove[i+1] - 2 * chapterContainerMargin)) {
-          $('.chapter-container').removeClass("inFocus").addClass("outFocus");
-          $('div#container' + i).addClass("inFocus").removeClass("outFocus");
+          $('.chapter-container').removeClass("in-focus").addClass("out-focus");
+          $('div#container' + i).addClass("in-focus").removeClass("out-focus");
           map.flyTo([chapters[i]['Longitude'], chapters[i]['Latitude']], chapters[i]['Zoom']);
         }
       }
     });
 
-    $('div#container0').addClass("inFocus");
-    $('#contents').append("<div class='space-at-the-bottom'><a href='#space-at-the-top'><i class='fa fa-chevron-up'></i></br><small>Top</small></a></div>");
+    $('#contents').append(" \
+      <div id='space-at-the-bottom'> \
+        <a href='#space-at-the-top'>  \
+          <i class='fa fa-chevron-up'></i></br> \
+          <small>Top</small>  \
+        </a> \
+      </div> \
+    ");
+
+    /* Generate a CSS sheet with cosmetic changes */
+    $("<style>")
+      .prop("type", "text/css")
+      .html("\
+      #narration, #title {\
+        background-color: " + trySetting('_narrativeBackground', 'white') + "; \
+        color: " + trySetting('_narrativeText', 'black') + "; \
+      }\
+      a, a:visited, a:hover {\
+        color: " + trySetting('_narrativeLink', 'blue') + " \
+      }\
+      .in-focus {\
+        background-color: " + trySetting('_narrativeActive', '#f0f0f0') + " \
+      }")
+      .appendTo("head");
+
+
+    endPixels = parseInt(getSetting('_pixelsAfterFinalChapter'));
+    if (endPixels > 100) {
+      $('#space-at-the-bottom').css({
+        'height': (endPixels / 2) + 'px',
+        'padding-top': (endPixels / 2) + 'px',
+      });
+    }
 
     var bounds = [];
     for (i in markers) {
@@ -198,6 +229,8 @@ $(window).on('load', function() {
 
     $('#map, #narration, #title').css('visibility', 'visible');
     $('div.loader').css('visibility', 'hidden');
+
+    $('div#container0').addClass("in-focus");
 
     $('div#contents').animate({scrollTop: '1px'});
   }

--- a/style.css
+++ b/style.css
@@ -73,15 +73,15 @@ h3 {
     margin-bottom: 0px;
 }
 
-.image-container {
-    /* margin + padding = imageContainerMargin in script.js */
+.chapter-container {
+    /* margin + padding = chapterContainerMargin in script.js */
     /* Important for scrolling! */
     margin: 50px 0 0 0;
     padding: 20px 0 0 0;
     text-align: center;
 }
 
-.image-container img {
+.chapter-container img {
     height: auto;
     width: auto;
     max-height: 100%;
@@ -95,7 +95,7 @@ h3 {
     transform: translateY(-50%);
 }
 
-.img-holder {
+.img-container {
     margin: 0px;
     height: 200px;
     max-height: 200px;

--- a/style.css
+++ b/style.css
@@ -128,13 +128,10 @@ h3 {
 
 .in-focus {
     opacity: 1.0;
-    /*background-color: #f0f0f0; */
 }
 
 .out-focus {
     opacity: 0.3;
-    /*background-color:hsl(180, 0%, 100%);
-    /* background-color: white; */
 }
 
 @media only screen and (max-device-width: 480px) {

--- a/style.css
+++ b/style.css
@@ -35,12 +35,12 @@ body {
     overflow-x: hidden;
 }
 
-#contents .space-at-the-top {
+#space-at-the-top {
     height: 30px;
     margin: 0px;
 }
 
-#contents .space-at-the-bottom {
+#space-at-the-bottom {
     height: 200px;
     margin: 0px;
     text-align: center;
@@ -126,14 +126,15 @@ h3 {
     padding: 20px;
 }
 
-.inFocus {
+.in-focus {
     opacity: 1.0;
-    background-color: #f0f0f0;
+    /*background-color: #f0f0f0; */
 }
 
-.outFocus {
+.out-focus {
     opacity: 0.3;
-    background-color: white;
+    /*background-color:hsl(180, 0%, 100%);
+    /* background-color: white; */
 }
 
 @media only screen and (max-device-width: 480px) {

--- a/style.css
+++ b/style.css
@@ -11,6 +11,7 @@ body {
     width: 70vw;
     height: 100vh;
     z-index: 1;
+    visibility: hidden;
 }
 
 #narration {
@@ -22,8 +23,8 @@ body {
     overflow: auto;
     z-index: 99;
     background: rgba(254,254,254, 1.0); /* to apply opacity background only. */
+    visibility: hidden;
 }
-
 
 #contents {
     padding: 0%;
@@ -65,6 +66,7 @@ body {
     z-index: 100;
     margin: 0px;
     padding: 0px;
+    visibility: hidden;
 }
 
 h3 {
@@ -159,5 +161,68 @@ h3 {
   }
   .leaflet-control-container {
       display: none;
+  }
+}
+
+
+/* CSS Loader */
+.loader,
+.loader:before,
+.loader:after {
+  background: #000;
+  -webkit-animation: load1 1s infinite ease-in-out;
+  animation: load1 1s infinite ease-in-out;
+  width: 1em;
+  height: 4em;
+}
+.loader:before,
+.loader:after {
+  position: absolute;
+  top: 0;
+  content: '';
+}
+.loader:before {
+  left: -1.5em;
+  -webkit-animation-delay: -0.32s;
+  animation-delay: -0.32s;
+}
+.loader {
+  color: #000;
+  text-indent: -9999em;
+  position: absolute;
+  left: 50vw;
+  top: 45vh;
+  font-size: 11px;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-animation-delay: -0.16s;
+  animation-delay: -0.16s;
+}
+.loader:after {
+  left: 1.5em;
+}
+@-webkit-keyframes load1 {
+  0%,
+  80%,
+  100% {
+    box-shadow: 0 0;
+    height: 4em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 5em;
+  }
+}
+@keyframes load1 {
+  0%,
+  80%,
+  100% {
+    box-shadow: 0 0;
+    height: 4em;
+  }
+  40% {
+    box-shadow: 0 -2em;
+    height: 5em;
   }
 }


### PR DESCRIPTION
* All HTML tags that exist in Description column are now valid (`<a>` links, `<b>` bold, `<i>` italics, etc., etc.). Resolves #2
* Loader added (3 jumping bars, just like in `leaflet-maps-with-google-sheets`). Resolves #3 
* #4 Multiple options added:
  * Narrative Width (in percentage, `30` by default)
  * Narrative Background Color (`white` by default)
  * Narrative Text Color (`black` by default)
  * Narrative Link Color (`blue` by default)
  * Active Chapter Background Color (`#f0f0f0` by default)
  * Image Container Height (`200` by default)
  * Pixels After Final Chapter (`300` by default)